### PR TITLE
인가를 위한 Interceptor 추가

### DIFF
--- a/src/main/java/imhong/dowith/common/WebConfig.java
+++ b/src/main/java/imhong/dowith/common/WebConfig.java
@@ -1,0 +1,20 @@
+package imhong.dowith.common;
+
+import imhong.dowith.common.interceptor.AuthInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final AuthInterceptor authInterceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(authInterceptor)
+            .excludePathPatterns("/auth/**");
+    }
+}

--- a/src/main/java/imhong/dowith/common/interceptor/AuthInterceptor.java
+++ b/src/main/java/imhong/dowith/common/interceptor/AuthInterceptor.java
@@ -1,0 +1,40 @@
+package imhong.dowith.common.interceptor;
+
+import imhong.dowith.common.security.JwtTokenProvider;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+@RequiredArgsConstructor
+public class AuthInterceptor implements HandlerInterceptor {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    public boolean preHandle(@NonNull HttpServletRequest request,
+        @NonNull HttpServletResponse response,
+        @NonNull Object handler) throws Exception {
+        String token = request.getHeader("Authorization");
+
+        if (token != null && token.startsWith("Bearer ")) {
+            token = token.substring(7);
+            if (jwtTokenProvider.validateToken(token)) {
+                String userId = jwtTokenProvider.getSubjectFromToken(token);
+                request.setAttribute("userId", userId);
+                return true;
+            } else {
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                response.getWriter().write("Unauthorized");
+                return false;
+            }
+        } else {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.getWriter().write("Unauthorized");
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
close #9 

## 완료된 작업

- [x] `/auth/**`를 제외한 모든 api에 토큰 검증하기

## 고민과 해결과정

### Filter를 쓸지 Interceptor를 쓸지
이 부분에 대해서 고민 많이 했는데요 일단 둘 다 써도 괜찮을 것 같다는 생각을 했습니다.
Servlet Filter의 경우에는 디스패처 서블릿에게 요청이 가기 전에 호출되고, Interceptor의 경우에는 디스패처 서블릿을 거친 후 Controller가 호출되기 전에 호출되는데 두 방법 다 토큰을 검증하는 역할에 있어서 문제가 없다고 판단했습니다.


그래서 결국 사용하기 더 쉬운 걸 선택했는데요
"`/auth` 를 제외한 나머지 url들은 토큰을 검증한다" 라는 요구사항을 정해두고 작성해보니 Interceptor가 패턴처리하기 더 유용하다고 판단이 섰습니다.

Filter의 경우에는 WebConfig에서 등록할때 urlPattern을 추가하는 기능만 있지 제외하는 기능은 없어서 아래와 같이 모든 url을 허용한 다음 filter 함수 내부에서 처리를 해줘야하기 때문에 filter가 반드시 호출된다는 단점이 있었습니다. 다음의 예제를 봅시다.

```java
@Configuration
public class WebConfig {

    @Bean
    public FilterRegistrationBean<AuthFilter> authFilterRegistrationBean(AuthFilter authFilter) {
        FilterRegistrationBean<AuthFilter> registrationBean = new FilterRegistrationBean<>();
        registrationBean.setFilter(authFilter);
        registrationBean.addUrlPatterns("/*");
        registrationBean.setOrder(1); 
        return registrationBean;
    }
}
```

```java
@Component
public class AuthFilter implements Filter {
//중략

    @Override
    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
            throws IOException, ServletException {
        HttpServletRequest httpRequest = (HttpServletRequest) request;
        HttpServletResponse httpResponse = (HttpServletResponse) response;

        String uri = httpRequest.getRequestURI();

        if (uri.startsWith("/auth/")) { //이렇게 필터함수 내부에서 처리 해야함
            chain.doFilter(request, response);
            return;
        }

        String token = httpRequest.getHeader("Authorization");
        if (token != null && token.startsWith("Bearer ")) {
            token = token.substring(7);
            if (jwtTokenProvider.validateToken(token)) {
                chain.doFilter(request, response);
            } else {
                httpResponse.setStatus(HttpStatus.UNAUTHORIZED.value());
                httpResponse.getWriter().write("Unauthorized");
            }
        } else {
            httpResponse.setStatus(HttpStatus.UNAUTHORIZED.value());
            httpResponse.getWriter().write("Unauthorized");
        }
    }
}
```

반면 Interceptor의 경우에는 WebConfig에서 등록할때 아래와 같이 excludePathPatterns 메서드가 제공되어 제가 Interceptor에 작성한 메서드가 호출조차 되지 않도록 할 수 있는 장점이 있었습니다. 따라서 검증하는 메서드 내부에서 해당 url이 제외되어야 하는 url인지 따로 확인할 필요가 없어집니다!

```java
@Configuration
public class WebConfig implements WebMvcConfigurer {
    @Override
    public void addInterceptors(InterceptorRegistry registry) {
        registry.addInterceptor(authInterceptor)
            .excludePathPatterns("/auth/**");
    }
}
```


따라서 Interceptor를 적용했습니다!


## 추가로
- challenge 관련 api들에서 모두 Member를 @RequestPart 로 받고 있던데, 이거 어떻게 인터셉터에서 넘겨주는지 모르겠습니다!?(임시로 해둔거 맞죠?) 글고 Interceptor에서 memberRepository통해서 db 호출하는건 아닌거 같아서 addAttribute로 userId만 넘겨주도록 했습니다. 아래는 컨트롤러에서 userId 받는 예시입니다.
  <img width="434" alt="스크린샷 2024-06-20 오후 5 14 15" src="https://github.com/yeim-hongo/dowith-backend/assets/56269396/bdff4c84-bbbb-4325-9dc0-8fc7168367fb">


