### PR TITLE
챌린지 전체 조회 추가

### DIFF
--- a/src/main/java/imhong/dowith/challenge/dto/ChallengeResponse.java
+++ b/src/main/java/imhong/dowith/challenge/dto/ChallengeResponse.java
@@ -1,0 +1,37 @@
+package imhong.dowith.challenge.dto;
+
+import imhong.dowith.challenge.domain.Challenge;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+public class ChallengeResponse {
+
+    private String title;
+    private String description;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private String status;
+    private int participantsCount;
+    private int minParticipantsCount;
+    private int maxParticipantsCount;
+    private String thumbnailUrl;
+
+    // TODO 도메인객체 <-> DTO 논의 필요
+    public static ChallengeResponse from(Challenge challenge) {
+        return new ChallengeResponse(
+            challenge.getTitle(),
+            challenge.getDescription(),
+            challenge.getStartDate(),
+            challenge.getEndDate(),
+            challenge.getStatus().toString(),
+            challenge.getParticipantsCount(),
+            challenge.getMinParticipantsCount(),
+            challenge.getMaxParticipantsCount(),
+            challenge.getThumbnailUrl()
+        );
+    }
+}

--- a/src/main/java/imhong/dowith/challenge/repository/ChallengeRepository.java
+++ b/src/main/java/imhong/dowith/challenge/repository/ChallengeRepository.java
@@ -1,8 +1,16 @@
 package imhong.dowith.challenge.repository;
 
 import imhong.dowith.challenge.domain.Challenge;
+import imhong.dowith.challenge.domain.ChallengeStatus;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ChallengeRepository extends JpaRepository<Challenge, Long> {
 
+    @Query("SELECT c FROM Challenge c")
+    Slice<Challenge> findAllSlice(Pageable pageable);
+
+    Slice<Challenge> findAllByStatus(ChallengeStatus status, Pageable pageable);
 }

--- a/src/main/java/imhong/dowith/challenge/service/ChallengeService.java
+++ b/src/main/java/imhong/dowith/challenge/service/ChallengeService.java
@@ -28,21 +28,24 @@ public class ChallengeService {
 
     public Long createChallenge(Member leader, ChallengeCreateRequest request) {
         // TODO ImageUploader를 트랜잭션에서 분리
+        String thumbnailUrl = request.getThumbnail() == null ? null : imageUploader.uploadThumbnail(request.getThumbnail());
         Challenge challenge = Challenge.create(
-            request.getTitle(),
-            request.getDescription(),
-            request.getVerificationRule(),
-            imageUploader.uploadThumbnail(request.getThumbnail()),
-            request.getStartDate(),
-            request.getEndDate(),
-            request.getMinParticipantsCount(),
-            request.getMaxParticipantsCount(),
-            leader.getId()
+                request.getTitle(),
+                request.getDescription(),
+                request.getVerificationRule(),
+                thumbnailUrl,
+                request.getStartDate(),
+                request.getEndDate(),
+                request.getMinParticipantsCount(),
+                request.getMaxParticipantsCount(),
+                leader.getId()
         );
         Challenge savedChallenge = challengeRepository.save(challenge);
-        imageRepository.saveAll(imageUploader.uploadImages(request.getImages(), savedChallenge));
+        if (request.getImages() != null) {
+            imageRepository.saveAll(imageUploader.uploadImages(request.getImages(), savedChallenge));
+        }
         memberChallengeRepository.save(
-            MemberChallenge.createLeader(leader.getId(), savedChallenge.getId()));
+                MemberChallenge.createLeader(leader.getId(), savedChallenge.getId()));
         return savedChallenge.getId();
     }
 


### PR DESCRIPTION
## 완료된 작업
- [x] 챌린지 전체 조회
   - [x] 페이징 처리 추가
   - [x] ChallengeStatus에 따른 필터링 처리 추가  

## 고민과 해결과정
JPA에서 페이징을 지원해주길래 사용해봤어요!
페이징한 값을 Page, Slice, List 세 가지 자료형으로 받아올 수 있는데, 각 자료형은 크게 다음과 같은 차이가 있었어요.
* Page : 이후 데이터가 더 존재하는지 여부 / 총 페이지 개수(count 쿼리 추가로 발생)
* Slice : 이후 데이터가 더 존재하는지 여부
* List : 우리가 잘 아는 리스트
저희는 무한 스크롤로 구현할 예정이니까 총 페이지 개수까지는 필요하지 않아서 Slice 자료형을 사용했습니다. 자세한 건 노션에 적어뒀습니다 감사합니다!
